### PR TITLE
Demonstrate using #max_class in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,8 @@ new_vectors = vectorizer.transform(['programming is fun'])
 probabilities = model.predict_probabilities(new_vectors.first)
 # => [0.9715681919147049, 0.028431808085295614]
 
-# to get the class of the maximum probability, look at the same index of the
-# unique_labels attribute on the model
-model.unique_labels[0] # => 'computers'
+# get the class of the maximum probability
+model.max_class(new_vectors.first)
 ```
 
 ## Development


### PR DESCRIPTION
Two guilty admissions:

1. I don't know much about machine learning, data science, let alone classifiers, the various matching algorithms.
2. I missed your talk at Indy.rb in November, and I haven't quite yet finished watching the video we recorded of it. I'm sorry. :-(

However, I have watched some, and I _learned_ of your _lurn_. As I was experimenting with it, I found the end of the README a bit confusing. Once I looked at the code, I realized that what I really wanted was `#max_class`, which you've written to conveniently go through the rigamarole of getting the index and finding that thing in the unique labels, etc. I thought I'd update the README to reflect that handy method. 

What do you think?